### PR TITLE
Borked namespace fix

### DIFF
--- a/src/Cilex/Provider/Console/Adapter/Silex/ConsoleServiceProvider.php
+++ b/src/Cilex/Provider/Console/Adapter/Silex/ConsoleServiceProvider.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Cilex\Pimple\Provider\Console\Adapter\Silex;
+namespace Cilex\Provider\Console\Adapter\Silex;
 
 use Cilex\Provider\Console\BaseConsoleServiceProvider;
 use Silex\Application;


### PR DESCRIPTION
Changed namespace to avoid fatal class not found error (Class 'Cilex\Provider\Console\Adapter\Silex\ConsoleServiceProvider' not found in ...)
