### PR TITLE
Updating to require pimple >=2.1,<4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php":             ">=5.3.3",
-        "pimple/pimple":   "~2.1@dev",
+        "pimple/pimple":   ">=2.1,<4",
         "symfony/console": "~2.4"
     },
     "autoload": {


### PR DESCRIPTION
Silex 2.0.x has been updated to require pimple ~3.0 which makes this library incompatible with silex 2.0.x. There is no difference between pimple 2.1.1 and 3.0.0 just a version bump.
